### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,6 @@ These projects are community contributed and not supported by Veracode. For a li
 
 - [Veracode-cli](https://github.com/adidas/veracode-cli) ([Adidas](https://github.com/adidas)) - Automated way to check application status and DevSecops compliance.
 
-- [Veracode Notifier](https://github.com/ctcampbell/veracode-notifier) ([Ctcampbell](https://github.com/ctcampbell)) - Lambda function that sends a message to a web hook, for instance for use with Slack
-
 - [VeraHooks Mitigation Webhooks](https://github.com/sebcoles/VeraHooks) ([Seb Coles](https://github.com/sebcoles)) - React .NET Core solution for creating custom webhooks that watch application profiles and trigger when mitigations meet specified conditions.
 
 ## Secure coding examples


### PR DESCRIPTION
Removed 'Veracode Notifier' repo authored by Chris Campbell (broken link/repo no longer available/now private)